### PR TITLE
Fix wireguard profile being activated after deactivating

### DIFF
--- a/bin/wg-quicker
+++ b/bin/wg-quicker
@@ -118,9 +118,11 @@ function toggle_profile() {
         local profile=$(basename "${1:-${profiles[0]}}" '.conf')
         # ensure profile is valid
         if [[ " ${profiles[@]} " =~ " ${profile} " ]]; then
-            # activate profile
-            echo "Activating profile: ${profile}"
-            sudo wg-quick up "${profile}"
+            # activate profile if it was not previously active
+            if [ "${current_profile}" != "${profile}" ]; then
+                echo "Activating profile: ${profile}"
+                sudo wg-quick up "${profile}"
+            fi
         else
             echo "Invalid profile: ${profile}"
         fi

--- a/doc/package.conf
+++ b/doc/package.conf
@@ -1,7 +1,7 @@
 __name__="wg-quicker"
 __namespace__="wg-quicker"
 __description__="Simple wireguard wrapper"
-__version__="0.1.1"
+__version__="0.1.2"
 __arch__=("any")
 __url__="https://github.com/irfanhakim-as/${__namespace__}"
 __license__=("GPL-3.0+")


### PR DESCRIPTION
# Changes

- Fixed `toggle_profile` to not activate the same profile it had just deactivated